### PR TITLE
Use wine for running on mac and linux

### DIFF
--- a/src/rcedit.coffee
+++ b/src/rcedit.coffee
@@ -27,6 +27,8 @@ module.exports = (exe, options, callback) ->
   child = spawn rcedit, args
 
   stderr = ''
+  child.on 'error', (err) ->
+    callback err
   child.stderr.on 'data', (data) -> stderr += data
   child.on 'close', (code) ->
     if code is 0


### PR DESCRIPTION
This PR just use wine when not windows to start rcedit. I tested it on my mac and the icon is correctly set (tested on windows).
