### PR TITLE
Add initial tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,5 @@ spec/
 src/
 test/
 script/
+.travis.yml
+appveyor.yml

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@ npm-debug.log
 script/
 spec/
 src/
+test/
+script/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+os:
+- linux
+- osx
+dist: trusty
+osx_image: xcode8
+language: node_js
+node_js:
+- '4'
+cache:
+- apt: true
+before_install: script/ci-setup.sh
+env:
+  global:
+    # prevent wine popup dialogs about installing additional packages
+    - WINEDLLOVERRIDES="mscoree,mshtml="

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,33 @@
 sudo: required
+
 os:
 - linux
 - osx
+
 dist: trusty
+
 osx_image: xcode8
+
 language: node_js
+
 node_js:
 - '4'
+
 cache:
 - apt: true
+
 before_install: script/ci-setup.sh
+
 env:
   global:
     # prevent wine popup dialogs about installing additional packages
     - WINEDLLOVERRIDES="mscoree,mshtml="
+
+branches:
+  only:
+  - master
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+build: off
+
+branches:
+  only:
+    - master
+
+skip_tags: true
+
+install:
+  - ps: Install-Product node LTS
+  - npm install npm
+  - .\node_modules\.bin\npm install
+
+test_script:
+  - node --version
+  - .\node_modules\.bin\npm --version
+  - .\node_modules\.bin\npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Node module to edit resources of exe",
   "main": "lib/rcedit.js",
   "scripts": {
-    "prepublish": "grunt prepublish"
+    "prepublish": "grunt prepublish",
+    "test": "mocha test/*.js"
   },
   "repository": {
     "type": "git",
@@ -20,10 +21,13 @@
     }
   ],
   "devDependencies": {
-    "grunt-contrib-coffee": "~0.7.0",
-    "grunt-cli": "~0.1.8",
     "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.8",
+    "grunt-coffeelint": "0.0.6",
+    "grunt-contrib-coffee": "~0.7.0",
     "grunt-shell": "~0.2.2",
-    "grunt-coffeelint": "0.0.6"
+    "mocha": "^3.0.2",
+    "rcinfo": "^0.1.3",
+    "temp": "^0.8.3"
   }
 }

--- a/script/ci-setup.sh
+++ b/script/ci-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -xe
+
+case "$TRAVIS_OS_NAME" in
+  "linux")
+    sudo apt-get update
+    sudo apt-get install -y wine1.6
+    ;;
+  "osx")
+    npm install wine-darwin@1.9.17-1
+    # Setup ~/.wine by running a command
+    ./node_modules/.bin/wine hostname
+    ;;
+esac

--- a/script/ci-setup.sh
+++ b/script/ci-setup.sh
@@ -2,6 +2,7 @@
 
 case "$TRAVIS_OS_NAME" in
   "linux")
+    sudo dpkg --add-architecture i386
     sudo apt-get update
     sudo apt-get install -y wine1.6
     ;;

--- a/test/rcedit-test.js
+++ b/test/rcedit-test.js
@@ -6,7 +6,7 @@ var rcinfo = require('rcinfo')
 var temp = require('temp').track()
 
 describe('rcedit(exePath, options, callback)', function () {
-  this.timeout(30000)
+  this.timeout(60000)
 
   var exePath = null
 

--- a/test/rcedit-test.js
+++ b/test/rcedit-test.js
@@ -1,0 +1,47 @@
+var assert = require('assert')
+var fs = require('fs')
+var path = require('path')
+var rcedit = require('..')
+var rcinfo = require('rcinfo')
+var temp = require('temp').track()
+
+describe('rcedit(exePath, options, callback)', function () {
+  this.timeout(30000)
+
+  var exePath = null
+
+  beforeEach(function () {
+    exePath = path.join(temp.mkdirSync('node-rcedit-'), 'electron.exe')
+    var fixturesExePath = path.join(__dirname, 'fixtures', 'electron.exe')
+    fs.writeFileSync(exePath, fs.readFileSync(fixturesExePath))
+  })
+
+  it('updates the information in the executable', function (done) {
+    var options = {
+      'version-string': {
+        CompanyName: 'Umbrella',
+        FileDescription: 'Vanhouten',
+        LegalCopyright: 'Maritime',
+        ProductName: 'Millhouse'
+      },
+      'file-version': '3.4.5.6',
+      'product-version': '4.5.6.7'
+    }
+    rcedit(exePath, options, function (error) {
+      if (error != null) return done(error)
+
+      rcinfo(exePath, function (error, info) {
+        if (error != null) return done(error)
+
+        assert.equal(info.CompanyName, 'Umbrella')
+        assert.equal(info.FileDescription, 'Vanhouten')
+        assert.equal(info.LegalCopyright, 'Maritime')
+        assert.equal(info.ProductName, 'Millhouse')
+        assert.equal(info.FileVersion, '3.4.5.6')
+        assert.equal(info.ProductVersion, '4.5.6.7')
+
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This pull requests add a test that uses the `rcinfo` module to verify the properties get set.

This also adds Travis and AppVeyor build configs so the tests run on Mac, Windows, and Linux CI.