### PR TITLE
Suppress Wine fixme log messages

### DIFF
--- a/lib/rcedit.js
+++ b/lib/rcedit.js
@@ -31,7 +31,11 @@ module.exports = function (exe, options, callback) {
     rcedit = 'wine'
   }
 
-  var child = spawn(rcedit, args)
+  var spawnOptions = {}
+  spawnOptions.env = Object.create(process.env)
+  spawnOptions.env.WINEDEBUG = '-all'
+
+  var child = spawn(rcedit, args, spawnOptions)
   var stderr = ''
   var error = null
 
@@ -50,7 +54,8 @@ module.exports = function (exe, options, callback) {
       callback()
     } else {
       var message = 'rcedit.exe failed with exit code ' + code
-      if (stderr) message += '.\n' + stderr
+      stderr = stderr.trim()
+      if (stderr) message += '. ' + stderr
       callback(new Error(message))
     }
   })

--- a/lib/rcedit.js
+++ b/lib/rcedit.js
@@ -26,14 +26,14 @@ module.exports = function (exe, options, callback) {
     }
   })
 
+  var spawnOptions = {}
+  spawnOptions.env = Object.create(process.env)
+
   if (process.platform !== 'win32') {
     args.unshift(rcedit)
     rcedit = 'wine'
+    spawnOptions.env.WINEDEBUG = '-all'
   }
-
-  var spawnOptions = {}
-  spawnOptions.env = Object.create(process.env)
-  spawnOptions.env.WINEDEBUG = '-all'
 
   var child = spawn(rcedit, args, spawnOptions)
   var stderr = ''

--- a/lib/rcedit.js
+++ b/lib/rcedit.js
@@ -32,6 +32,7 @@ module.exports = function (exe, options, callback) {
   if (process.platform !== 'win32') {
     args.unshift(rcedit)
     rcedit = 'wine'
+    // Supress fixme: stderr log messages
     spawnOptions.env.WINEDEBUG = '-all'
   }
 

--- a/test/rcedit-test.js
+++ b/test/rcedit-test.js
@@ -110,7 +110,8 @@ describe('rcedit(exePath, options, callback)', function () {
   it('reports an error when the .exe path does not exist', function (done) {
     rcedit(path.join(tempPath, 'does-not-exist.exe'), {'file-version': '3.4.5.6'}, function (error) {
       assert.ok(error instanceof Error)
-      assert.equal(error.message, 'rcedit.exe failed with exit code 1. Fatal error: Unable to load file')
+      assert.notEqual(error.message.indexOf('rcedit.exe failed with exit code 1.'), -1)
+      assert.notEqual(error.message.indexOf('Fatal error: Unable to load file'), -1)
 
       done()
     })

--- a/test/rcedit-test.js
+++ b/test/rcedit-test.js
@@ -110,8 +110,7 @@ describe('rcedit(exePath, options, callback)', function () {
   it('reports an error when the .exe path does not exist', function (done) {
     rcedit(path.join(tempPath, 'does-not-exist.exe'), {'file-version': '3.4.5.6'}, function (error) {
       assert.ok(error instanceof Error)
-      assert.notEqual(error.message.indexOf('rcedit.exe failed with exit code'), -1)
-      assert.notEqual(error.message.indexOf('Fatal error: Unable to load file'), -1)
+      assert.equal(error.message, 'rcedit.exe failed with exit code 1. Fatal error: Unable to load file')
 
       done()
     })


### PR DESCRIPTION
Previously on failures, many `fixme:` lines would be in the stderr output from Wine.

This pull request sets `WINEDEBUG` to `-all` to suppress all these logs.

https://wiki.winehq.org/FAQ#I_get_lots_of_.22fixme:.22_messages_in_the_terminal_and_Wine_runs_a_bit_slow

### Error messages before

```
rcedit.exe failed with exit code 1. fixme:winediag:start_process Wine Staging 1.9.16 is a testing version containing experimental patches.
fixme:winediag:start_process Please mention your exact version when filing bug reports on winehq.org.
fixme:ntdll:NtCreateNamedPipeFile Message mode not supported, falling back to byte mode.
fixme:ntdll:NtCreateNamedPipeFile Message mode not supported, falling back to byte mode.
fixme:ntdll:NtCreateNamedPipeFile Message mode not supported, falling back to byte mode.
fixme:module:load_library unsupported flag(s) used (flags: 0x00000800)
fixme:module:load_library unsupported flag(s) used (flags: 0x00000800)
fixme:module:load_library unsupported flag(s) used (flags: 0x00000800)
fixme:ntdll:EtwEventRegister {5eec90ab-c022-44b2-a5dd-fd716a222a15}, 0x406ba9, 0x4c90b0, 0x4c90c8
fixme:ntdll:EtwEventSetInformation 2, 0x4c255a, 43
fixme:module:load_library unsupported flag(s) used (flags: 0x00000800)
fixme:module:load_library unsupported flag(s) used (flags: 0x00000800)
fixme:module:load_library unsupported flag(s) used (flags: 0x00000800)
Fatal error: Unable to load file
fixme:module:load_library unsupported flag(s) used (flags: 0x00000800)
fixme:ver:GetCurrentPackageId (0x32fd64 0x0): stub
fixme:ntdll:NtCreateNamedPipeFile Message mode not supported, falling back to byte mode.
```

### Error messages after

```
rcedit.exe failed with exit code 1. Fatal error: Unable to load file
```