### PR TITLE
Add documentation for version-string

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ On platforms other than Windows, you will need to have [Wine](http://winehq.org)
 * `application-manifest` - String path to a local manifest file to use.
   See [here](https://msdn.microsoft.com/en-us/library/windows/desktop/aa374191.aspx)
   for more details.
+ 
+`version-string` allows you to set the PE file meta keys, such as in the following example:
+
+```
+var options = {
+
+	'icon': 'res/icon.ico',
+	'file-version': '1.0.0',
+	'product-version': '1.0.0',
+
+	'version-string': {
+		'CompanyName': 'Acme Inc.',
+		'FileDescription': 'A test file',
+		'LegalCopyright': 'Copyright (C) Acme Inc.',
+		'ProductName': 'My Test'
+	}
+
+};
+```
 
 `callback` is the `Function` called when the command completes. The function
 signature is `function (error)`.


### PR DESCRIPTION
node-rcedit was also suffering the lack of documentation for `version-string` mentioned on electron/rcedit#2

This PR adds to the README examples of usage of the object, as seen on [unindented/grunt-rcedit](https://github.com/unindented/grunt-rcedit/)

By the way, unindented/grunt-rcedit#1 has added a table to the README that lists every possible key and explains what it means. However it doesn't fit to me to tell whether this repo must bring that information or if users should find that information on official sources (i.e.: MSDN).