### PR TITLE
2.0 docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to `node-rcedit`
+
+## Code of Conduct
+
+This project is a part of the Electron ecosystem. As such, all contributions to this project follow [Electron's code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
+where appropriate.
+
+## Bugs / Feature Requests
+
+Most bugs and feature requests in `node-rcedit` can be attributed to
+[`rcedit`](https://github.com/electron/rcedit) itself. Please look in that project's issue tracker
+first before filing an issue here.
+
+## Releases
+
+`node-rcedit` uses `semantic-release` plus a plugin named "continuous factor authentication" to
+publish new releases to NPM. When a pull request is merged, a new release is queued in CircleCI, and
+a member of the Electron [Docs & Tools Working Group](https://github.com/electron/governance/tree/master/wg-docs-tools) needs to approve it.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Node module to edit resources of Windows executables.
 
 ## Docs
 
-```js
-var rcedit = require('rcedit')
+```javascript
+const rcedit = require('rcedit')
 ```
+
 On platforms other than Windows, you will need to have [Wine](http://winehq.org)
 1.6 or later installed and in the system path.
 
-### `rcedit(exePath, options, callback)`
+### `async rcedit(exePath, options)`
 
 `exePath` is the path to the Windows executable to be modified.
 
@@ -32,8 +33,7 @@ On platforms other than Windows, you will need to have [Wine](http://winehq.org)
   See [here](https://msdn.microsoft.com/en-us/library/windows/desktop/aa374191.aspx)
   for more details.
 
-`callback` is the `Function` called when the command completes. The function
-signature is `function (error)`.
+Returns a `Promise` with no value.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@
 
 Node module to edit resources of Windows executables.
 
-## Building
-
-* Clone the repository
-* Run `npm install`
-* Run `npm test` to run the tests
-
 ## Docs
 
 ```js
@@ -40,3 +34,9 @@ On platforms other than Windows, you will need to have [Wine](http://winehq.org)
 
 `callback` is the `Function` called when the command completes. The function
 signature is `function (error)`.
+
+## Building
+
+* Clone the repository
+* Run `npm install`
+* Run `npm test` to run the tests

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,9 @@
+# Support for `node-rcedit`
+
+## Troubleshooting
+
+This module uses the [`debug`](https://npm.im/debug) module to print out debugging information. To
+use it, consult your operating system's documentation on setting environment variables _([Windows
+notes](https://github.com/visionmedia/debug#windows-command-prompt-notes))_. Set the `DEBUG`
+environment variable to `rcedit`, and it will print out information, including any `STDERR` output
+from `rcedit.exe`.


### PR DESCRIPTION
I screwed up the commit message of #40, so here's a brown paper bag PR so maybe we can get a 2.0 release for real: :cry: :see_no_evil: 

Squash & Merge commit message:

```
docs: update for 2.0

BREAKING CHANGE: commit ead1083 dropped support for Node < 8.

* chore: add CONTRIBUTING/support docs
* docs: put building docs after API docs
* docs: promisify API docs
```