### PR TITLE
feat: add support for WSL

### DIFF
--- a/lib/rcedit.js
+++ b/lib/rcedit.js
@@ -1,3 +1,4 @@
+const os = require('os')
 const path = require('path')
 const { spawn } = require('child_process')
 
@@ -33,7 +34,8 @@ module.exports = async (exe, options) => {
     env: { ...process.env }
   }
 
-  if (process.platform !== 'win32') {
+  // Use Wine on non-Windows platforms except for WSL, which doesn't need it
+  if (process.platform !== 'win32' && !os.release().endsWith('Microsoft')) {
     args.unshift(rcedit)
     rcedit = process.arch === 'x64' ? 'wine64' : 'wine'
     // Suppress "fixme:" stderr log messages


### PR DESCRIPTION
Simple PR which skips using Wine in Window Subsystem for Linux (WSL) as WSL can run EXEs natively, so no need for Wine.

I've tested this using electron-packager to build for Windows in WSL, and it worked as expected.