### PR TITLE
ci: use Node 14 for the release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:10.15
+      - image: circleci/node:14.15.1
     steps:
       - checkout
       - *step-restore-cache


### PR DESCRIPTION
Should fix the [CI failure](https://app.circleci.com/pipelines/github/electron/node-rcedit/84/workflows/b7318e06-dd6d-43da-beab-1eae6a5a9375/jobs/377).