### PR TITLE
fix: Wrong executable path on WSL

### DIFF
--- a/lib/rcedit.js
+++ b/lib/rcedit.js
@@ -1,4 +1,4 @@
-const { canRunWindowsExeNatively, is64BitArch, spawnExe } = require('cross-spawn-windows-exe')
+const { canRunWindowsExeNatively, is64BitArch, spawnExe, normalizePath } = require('cross-spawn-windows-exe')
 const path = require('path')
 
 const pairSettings = ['version-string']
@@ -8,7 +8,7 @@ const noPrefixSettings = ['application-manifest']
 module.exports = async (exe, options) => {
   const rceditExe = is64BitArch(process.arch) ? 'rcedit-x64.exe' : 'rcedit.exe'
   const rcedit = path.resolve(__dirname, '..', 'bin', rceditExe)
-  const args = [exe]
+  const args = [await normalizePath(exe)]
 
   for (const name of pairSettings) {
     if (options[name]) {


### PR DESCRIPTION
The path of executable file to be modified is not parsed properly on WSL, without `normalizePath`, it will try to modify the path inside WSL, which is not recognized properly, this PR fixed the problem.

```
Unable to load file: "/tmp/electron-packager/win32-x64/zheng-desktop-template-win32-x64/zheng-desktop-template.exe"
    at ChildProcess.<anonymous> (/mnt/d/dev/zheng-desktop-template/node_modules/cross-spawn-windows-exe/node_modules/@malept/cross-spawn-promise/src/index.ts:172:16)
    at ChildProcess.emit (events.js:375:28)
    at ChildProcess.emit (domain.js:470:12)
    at maybeClose (internal/child_process.js:1055:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:288:5) {
  cmd: '/mnt/d/dev/zheng-desktop-template/node_modules/rcedit/bin/rcedit-x64.exe',
  args: [
    '/tmp/electron-packager/win32-x64/zheng-desktop-template-win32-x64/zheng-desktop-template.exe',
    '--set-version-string',
    'FileDescription',
    'zheng-desktop-template',
    '--set-version-string',
    'InternalName',
    'zheng-desktop-template',
    '--set-version-string',
    'OriginalFilename',
    'zheng-desktop-template.exe',
    '--set-version-string',
    'ProductName',
    'zheng-desktop-template',
    '--set-version-string',
    'CompanyName',
    'Losses Don',
    '--set-file-version',
    '1.0.0',
    '--set-product-version',
    '1.0.0'
  ],
  stdout: '',
  stderr: 'Unable to load file: "/tmp/electron-packager/win32-x64/zheng-desktop-template-win32-x64/zheng-desktop-template.exe"\r\n',
  code: 1
}

Electron Forge was terminated. Location:
{}
```

Please notice the first argument:
```
    '/tmp/electron-packager/win32-x64/zheng-desktop-template-win32-x64/zheng-desktop-template.exe',
```

This is incorrect ;)