### PR TITLE
feat: support setting resource strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ const rcedit = require('rcedit')
 * `application-manifest` - String path to a local manifest file to use.
   See [here](https://msdn.microsoft.com/en-us/library/windows/desktop/aa374191.aspx)
   for more details.
+* `resource-string` - An object in the form of `{ [id]: value }` to add to the
+  [string table](https://docs.microsoft.com/en-us/windows/win32/menurc/stringtable-resource).
 
 Returns a `Promise` with no value.
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -37,6 +37,13 @@ declare namespace rcedit {
     ProductName?: string
   }
   /**
+   * Resource strings. See [string table](https://docs.microsoft.com/en-us/windows/win32/menurc/stringtable-resource)
+   * for details.
+   */
+  interface ResourceStrings {
+    [n: number]: string
+  }
+  /**
    * EXE metadata that can be changed.
    */
   interface Options {
@@ -62,6 +69,10 @@ declare namespace rcedit {
      * XML that is to be embedded in the EXE.
      */
     'application-manifest'?: string
+    /**
+     * Set resource strings.
+     */
+    'resource-string'?: ResourceStrings
   }
 }
 

--- a/lib/rcedit.js
+++ b/lib/rcedit.js
@@ -1,7 +1,7 @@
 const { canRunWindowsExeNatively, is64BitArch, spawnExe } = require('cross-spawn-windows-exe')
 const path = require('path')
 
-const pairSettings = ['version-string']
+const pairSettings = ['version-string', 'resource-string']
 const singleSettings = ['file-version', 'product-version', 'icon', 'requested-execution-level']
 const noPrefixSettings = ['application-manifest']
 

--- a/test/rcedit-test.js
+++ b/test/rcedit-test.js
@@ -105,6 +105,18 @@ describe('async rcedit(exePath, options)', function () {
     assert.ok(exeData.includes('requireAdministrator'))
   })
 
+  it('supports setting resource strings', async () => {
+    let exeData = await readFile(exePath, 'utf16le')
+    assert.ok(!exeData.includes('bonfire'))
+    assert.ok(!exeData.includes('mumbai'))
+
+    await rcedit(exePath, { 'resource-string': { 1: 'bonfire', 2: 'mumbai' } })
+
+    exeData = await readFile(exePath, 'utf16le')
+    assert.ok(exeData.includes('bonfire'))
+    assert.ok(exeData.includes('mumbai'))
+  })
+
   it('reports an error when the .exe path does not exist', async () => {
     await assertRceditError(path.join(tempPath, 'does-not-exist.exe'), { 'file-version': '3.4.5.6' }, [
       'Command failed with a non-zero return code (1)',


### PR DESCRIPTION
rcedit supports `--set-resource-string <id> <value>` but this was not yet exposed here.