### PR TITLE
fix: don't publish unnecessary files in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.npmignore
-.DS_Store
-npm-debug.log
-script/
-spec/
-test/
-script/
-.travis.yml
-appveyor.yml

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Node module to edit resources of exe",
   "main": "lib/rcedit.js",
   "types": "lib/index.d.ts",
+  "files": [
+    "bin",
+    "lib/index.d.ts"
+  ],
   "scripts": {
     "docs:build": "node script/build-docs.js",
     "mocha": "mocha test/*.js",


### PR DESCRIPTION
Specifically this will exclude the following files which are currently in the published package:
* `.circleci/`
* `.releaserc.json`
* `CONTRIBUTING.md`
* `SUPPORT.md`
* `tsconfig.eslint.json`