### PR TITLE
ci: remove empty Homebrew cask

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
                     ;;
                     Darwin)
                       brew install --cask xquartz
-                      brew tap homebrew/cask-versions
                       brew install --cask --no-quarantine wine-stable
                     ;;
                   esac


### PR DESCRIPTION
This isn't necessary to install Wine and started throwing an error [as it is deprecated](https://github.com/Homebrew/homebrew-cask-versions) and now empty.