### PR TITLE
ci: revert runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - '14.21'
         os:
           - macos-latest
-          - ubuntu-latest
+          - ubuntu-22.04
           - windows-latest
     runs-on: "${{ matrix.os }}"
     steps:
@@ -38,7 +38,7 @@ jobs:
           path: /usr/local/Homebrew
           key: v1-brew-cache-${{ matrix.os }}
       - name: Install OS Dependencies (Linux)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update


### PR DESCRIPTION
`ubuntu-latest` is now Ubuntu 24.04 and an issue has cropped up where `wine64` isn't found despite installing successfully. To unblock CI here for now, revert to Ubuntu 22.04 until that issue can be debugged.