### PR TITLE
ci: force wine binary to not be wine64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   test:
     name: Test
+    env:
+      WINE_BINARY: 'wine'
     strategy:
       matrix:
         node-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           - '14.21'
         os:
           - macos-latest
-          - ubuntu-22.04
+          - ubuntu-latest
           - windows-latest
     runs-on: "${{ matrix.os }}"
     steps:
@@ -40,7 +40,7 @@ jobs:
           path: /usr/local/Homebrew
           key: v1-brew-cache-${{ matrix.os }}
       - name: Install OS Dependencies (Linux)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update


### PR DESCRIPTION
The latest `wine-stable` cask on Homebrew no longer ships `wine64`.

This also allows reverting #135 which may have been prompted by a similar root cause (with `wine64` binaries disappearing in Ubuntu).